### PR TITLE
[BUGFIX] Prevent trashing multi-line Blade attributes

### DIFF
--- a/src/ServiceProvider.php
+++ b/src/ServiceProvider.php
@@ -63,10 +63,18 @@ class ServiceProvider extends IlluminateServiceProvider
             'components',
         );
 
-        $componentStackCompiler = new BladeComponentStacksCompiler;
+        /** @var BladeComponentStacksCompiler $componentStackCompiler */
+        $componentStackCompiler = app(BladeComponentStacksCompiler::class);
+
+        Blade::directive('component', function ($expression) use ($componentStackCompiler) {
+            return $componentStackCompiler->compileComponent($expression);
+        });
+
+        Blade::directive('endComponentClass', function ($expression) use ($componentStackCompiler) {
+            return $componentStackCompiler->compileEndComponentClass($expression);
+        });
 
         Blade::prepareStringsForCompilationUsing(fn ($template) => Compiler::compile($template));
-        Blade::precompiler(fn ($template) => $componentStackCompiler->compile($template));
     }
 
     protected function bootEvents()

--- a/tests/Runtime/BladeComponentInteropTest.php
+++ b/tests/Runtime/BladeComponentInteropTest.php
@@ -38,3 +38,30 @@ BLADE;
         Str::squish($this->render($template))
     );
 });
+
+test('compiler injects stack behaviors into multi-line Blade tags', function () {
+    $template = <<<'BLADE'
+<x-alert :thing="[
+    'multi' => 'line',
+    'test' => 'here'
+]" />
+BLADE;
+
+    $this->assertSame(
+        'Blade component test. ',
+        $this->render($template)
+    );
+});
+
+test('Blade component stacks', function () {
+    $expected = <<<'BLADE'
+Component B: The Title
+Component C: The Title
+Component E: The Title Nope
+BLADE;
+
+    $this->assertSame(
+        $expected,
+        $this->render('<x-component_a title="The Title" /> <x-component_f />')
+    );
+});

--- a/tests/resources/views/components/component_a.blade.php
+++ b/tests/resources/views/components/component_a.blade.php
@@ -1,0 +1,7 @@
+@props(['title'])
+
+<x-component_b />
+
+<x-component_c />
+
+<x-component_d />

--- a/tests/resources/views/components/component_b.blade.php
+++ b/tests/resources/views/components/component_b.blade.php
@@ -1,0 +1,3 @@
+@aware(['title'])
+
+Component B: {{ $title }}

--- a/tests/resources/views/components/component_c.blade.php
+++ b/tests/resources/views/components/component_c.blade.php
@@ -1,0 +1,3 @@
+@aware(['title'])
+
+Component C: {{ $title }}

--- a/tests/resources/views/components/component_d.blade.php
+++ b/tests/resources/views/components/component_d.blade.php
@@ -1,0 +1,1 @@
+<x-component_e />

--- a/tests/resources/views/components/component_e.blade.php
+++ b/tests/resources/views/components/component_e.blade.php
@@ -1,0 +1,3 @@
+@aware(['title'])
+
+Component E: {{ $title }}

--- a/tests/resources/views/components/component_f.blade.php
+++ b/tests/resources/views/components/component_f.blade.php
@@ -1,0 +1,3 @@
+@aware(['title' => 'Nope'])
+
+{{ $title }}


### PR DESCRIPTION
Corrects an issue where stack injection would fail if the Blade component contains multiple lines. This PR refactors that to use custom directives and reflection.