### PR TITLE
Improves attribute compilation

### DIFF
--- a/src/Compiler/AttributeCompiler.php
+++ b/src/Compiler/AttributeCompiler.php
@@ -54,9 +54,9 @@ class AttributeCompiler
         })->implode('');
     }
 
-    public function compile(array $parameters): string
+    public function compile(array $parameters, array $propNames = []): string
     {
-        return '['.implode(',', $this->toCompiledArray($parameters)).']';
+        return '['.implode(',', $this->toCompiledArray($parameters, $propNames)).']';
     }
 
     public function getLastCompiledNames(): array
@@ -91,7 +91,7 @@ class AttributeCompiler
     /**
      * @param  ParameterNode[]  $parameters
      */
-    public function toCompiledArray(array $parameters): array
+    public function toCompiledArray(array $parameters, array $propNames = []): array
     {
         $this->compiledValues = $this->compiledParamNames = [];
 
@@ -105,7 +105,7 @@ class AttributeCompiler
             $paramName = $paramValue = null;
 
             if ($parameter->type == ParameterType::Parameter) {
-                $paramName = Str::camel($parameter->name);
+                $paramName = in_array($parameter->name, $propNames) ? Str::camel($parameter->name) : $parameter->name;
                 $paramValue = $this->arrayValue($parameter->value);
                 $compiledParameters[] = $this->toArraySyntax($paramName, $paramValue);
             } elseif ($parameter->type == ParameterType::DynamicVariable) {

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -434,7 +434,11 @@ final class TemplateCompiler
 
             $innerTemplate = $this->compileStencils($componentModel, $extractions, $innerTemplate);
 
-            $compiledComponentParams = $this->attributeCompiler->compile($this->filterComponentParams($node->parameters ?? []));
+            $compiledComponentParams = $this->attributeCompiler->compile(
+                $this->filterComponentParams($node->parameters ?? []),
+                $componentModel->getPropNames(),
+            );
+
             $this->activeComponent->compiledComponentAttributes = $this->attributeCompiler->getLastCompiledNames();
 
             $compiledComponentTemplate = <<<'PHP'

--- a/tests/Compiler/AttributesTest.php
+++ b/tests/Compiler/AttributesTest.php
@@ -68,3 +68,10 @@ BLADE;
         $this->render($template)
     );
 });
+
+test('hyphenated attributes are not case converted', function () {
+    $this->assertSame(
+        '<div data-thing="the thing">The Title</div>',
+        $this->render('<c-button data-thing="the thing" title="The Title" />')
+    );
+});

--- a/tests/resources/components/button.blade.php
+++ b/tests/resources/components/button.blade.php
@@ -1,0 +1,3 @@
+@props(['title'])
+
+<div {{ $attributes }}>{{ $title }}</div>


### PR DESCRIPTION
Corrects an issue when compilating hyphenated attributes, such as `data-something="the super cool and extremely awesome value"`