### PR TITLE
Improve attribute echo compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - `@aware` variables are automatically removed from the attribute bag, without needing to redefine them in `@props`
 - Adds support for passing attributes via. the `<c-component {{ $attributes }} />` attribute
+- Bumps minimum version of `stillat/blade-parser` to 1.10.3
+- Adds support for compiling component attributes of the form `<c-component attribute={{ $value }} />`
+- Adds support for compiling component attributes of the form `<c-component attribute={{{ $value }}} />`
+- Adds support for compiling component attributes of the form `<c-component attribute={!! $value !!} />`
 
 ## [v1.0.4](https://github.com/Stillat/dagger/compare/v1.0.3...v1.0.4) - 2025-01-21
 

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "laravel/framework": "^11.9",
-        "stillat/blade-parser": "^1.10.1",
+        "stillat/blade-parser": "^1.10.3",
         "nikic/php-parser": "^5",
         "symfony/var-exporter": "^6.0"
     },

--- a/tests/Compiler/AttributesTest.php
+++ b/tests/Compiler/AttributesTest.php
@@ -99,3 +99,19 @@ EXPECTED;
         $this->render($bladeTemplate)
     );
 });
+
+test('echo attribute value', function () {
+    $template = <<<'BLADE'
+<c-button
+    title="The Button Title"
+    data-one={{ $value }}
+    data-two={{{ $value }}}
+    data-three={!! $value !!}
+/>
+BLADE;
+
+    $this->assertSame(
+        '<div data-one="&amp;&amp;" data-two="&amp;&amp;" data-three="&&">The Button Title</div>',
+        $this->render($template, ['value' => '&&'])
+    );
+});


### PR DESCRIPTION
- Adds support for compiling component attributes of the form `<c-component attribute={{ $value }} />`
- Adds support for compiling component attributes of the form `<c-component attribute={{{ $value }}} />`
- Adds support for compiling component attributes of the form `<c-component attribute={!! $value !!} />`