### PR TITLE
Passed attributes will become part of component data

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Adds support for compiling component attributes of the form `<c-component attribute={{ $value }} />`
 - Adds support for compiling component attributes of the form `<c-component attribute={{{ $value }}} />`
 - Adds support for compiling component attributes of the form `<c-component attribute={!! $value !!} />`
+- Multi-word prop values will be available on nested components when passing `$attributes` to a child component
 
 ## [v1.0.4](https://github.com/Stillat/dagger/compare/v1.0.3...v1.0.4) - 2025-01-21
 

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -444,7 +444,7 @@ final class TemplateCompiler
             $compiledComponentTemplate = <<<'PHP'
 <?php
 try {
-$__componentData = $compiledParams;
+$__componentData = \Stillat\Dagger\Runtime\Attributes::mergeNestedAttributes($compiledParams, $compiledPropNames);
 /** COMPILE:PROPS_DEFAULT */
 /** COMPILE_IF_VAR:componentGlobalScope $targetVar = get_defined_vars(); */
 $__slotContainerVarSuffix = new \Stillat\Dagger\Runtime\SlotContainer;

--- a/src/Runtime/Attributes.php
+++ b/src/Runtime/Attributes.php
@@ -1,0 +1,47 @@
+<?php
+
+namespace Stillat\Dagger\Runtime;
+
+use Illuminate\Support\Str;
+use Illuminate\View\ComponentAttributeBag;
+
+class Attributes
+{
+    public static function mergeNestedAttributes(array $data, array $props): array
+    {
+        if (! isset($data['attributes']) || empty($props)) {
+            return $data;
+        }
+
+        $attributes = $data['attributes'];
+
+        if ($attributes instanceof ComponentAttributeBag) {
+            $attributeData = $attributes->all();
+        } elseif (is_array($attributes)) {
+            $attributeData = $attributes;
+        } else {
+            return $data;
+        }
+
+        $adjustedData = [];
+
+        foreach ($attributeData as $key => $value) {
+            $camelCased = Str::camel($key);
+
+            if (isset($props[$camelCased])) {
+                $key = $camelCased;
+            }
+
+            $adjustedData[$key] = $value;
+        }
+
+        unset($attributeData);
+        $data = array_merge($adjustedData, $data);
+
+        if ($data['attributes'] === $attributes) {
+            unset($data['attributes']);
+        }
+
+        return $data;
+    }
+}

--- a/tests/Compiler/AttributesTest.php
+++ b/tests/Compiler/AttributesTest.php
@@ -115,3 +115,27 @@ BLADE;
         $this->render($template, ['value' => '&&'])
     );
 });
+
+test('passed attributes are merged into the data', function () {
+    // Framework Reference: https://github.com/laravel/framework/issues/48956
+
+    $this->assertSame(
+        'the one second value | ',
+        $this->render('<c-attribute_merging.bar one="the one" two-word="second value" />'),
+    );
+
+    $this->assertSame(
+        'none second value | ',
+        $this->render('<c-attribute_merging.bar two-word="second value" />'),
+    );
+
+    $this->assertSame(
+        'none none | ',
+        $this->render('<c-attribute_merging.bar />'),
+    );
+
+    $this->assertSame(
+        'the one second value | class="one two three"',
+        $this->render('<c-attribute_merging.bar one="the one" two-word="second value" class="one two three" />'),
+    );
+});

--- a/tests/resources/components/attribute_merging/bar.blade.php
+++ b/tests/resources/components/attribute_merging/bar.blade.php
@@ -1,0 +1,1 @@
+<c-attribute_merging.foo :$attributes></c-attribute_merging.foo>

--- a/tests/resources/components/attribute_merging/foo.blade.php
+++ b/tests/resources/components/attribute_merging/foo.blade.php
@@ -1,0 +1,5 @@
+@props([
+    'one' => 'none',
+    'twoWord' => 'none',
+])
+{{ $one }} {{ $twoWord }} | {{ $attributes }}


### PR DESCRIPTION
When passing `$attributes` to child components that define props, multi-word/hyphenated attributes will become part of the nested component's prop data:

```blade
<!-- resources/dagger/views/wrapper.blade.php -->

<c-child :$attributes />
```

```blade
<!-- resources/dagger/views/child.blade.php -->
@props(['one', 'twoWords'])

{{ $one }} {{ $twoWords }}
```

```blade
<!-- resources/views/template.blade.php -->

<c-wrapper one="one" two-words="two" />
```