### PR TITLE
Cache parsed component models

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - Adds support for compiling component attributes of the form `<c-component attribute={{{ $value }}} />`
 - Adds support for compiling component attributes of the form `<c-component attribute={!! $value !!} />`
 - Multi-word prop values will be available on nested components when passing `$attributes` to a child component
+- Internal component model instances will be cached during compilation, improving performance for heavily re-used components
 
 ## [v1.0.4](https://github.com/Stillat/dagger/compare/v1.0.3...v1.0.4) - 2025-01-21
 

--- a/src/Compiler/ComponentState.php
+++ b/src/Compiler/ComponentState.php
@@ -66,9 +66,22 @@ class ComponentState
 
     public function __construct(
         public ?ComponentNode $node,
-        public readonly string $varSuffix,
+        public string $varSuffix,
     ) {
+        $this->updateNodeDetails($this->node, $this->varSuffix);
+    }
+
+    /**
+     * @internal
+     */
+    public function updateNodeDetails(?ComponentNode $node, string $varSuffix): static
+    {
+        $this->node = $node;
+        $this->varSuffix = $varSuffix;
+
         $this->compilerId = '{'.$this->node?->id ?? $this->varSuffix.'}';
+
+        return $this;
     }
 
     public function getCachePrefix(): string

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -29,6 +29,7 @@ use Stillat\Dagger\Exceptions\InvalidCompilerParameterException;
 use Stillat\Dagger\Exceptions\Mapping\LineMapper;
 use Stillat\Dagger\Exceptions\MissingComponentNamespaceException;
 use Stillat\Dagger\Facades\SourceMapper;
+use Stillat\Dagger\Parser\ComponentCache;
 use Stillat\Dagger\Parser\ComponentParser;
 use Stillat\Dagger\Runtime\ViewManifest;
 use Stillat\Dagger\Support\Utils;
@@ -119,7 +120,7 @@ final class TemplateCompiler
         $this->staticTemplateCompiler = new StaticTemplateCompiler;
         $this->replacementManager = new ReplacementManager;
         $this->componentCompiler = new ComponentCompiler;
-        $this->componentParser = new ComponentParser;
+        $this->componentParser = new ComponentParser(new ComponentCache);
         $this->compiler = Blade::getFacadeRoot();
         $this->attributeCompiler = new AttributeCompiler;
     }
@@ -578,6 +579,7 @@ PHP;
 
     public function cleanup(): void
     {
+        $this->componentParser->getComponentCache()->clear();
         $this->componentBlocks = [];
         $this->replacementManager->clear();
     }

--- a/src/Parser/ComponentCache.php
+++ b/src/Parser/ComponentCache.php
@@ -1,0 +1,29 @@
+<?php
+
+namespace Stillat\Dagger\Parser;
+
+use Stillat\Dagger\Compiler\ComponentState;
+
+class ComponentCache
+{
+    protected array $items = [];
+
+    public function get(string $key): ?ComponentState
+    {
+        if (! isset($this->items[$key])) {
+            return null;
+        }
+
+        return clone $this->items[$key];
+    }
+
+    public function put(string $key, ComponentState $componentState): void
+    {
+        $this->items[$key] = $componentState;
+    }
+
+    public function clear(): void
+    {
+        $this->items = [];
+    }
+}

--- a/tests/CompilerTestCase.php
+++ b/tests/CompilerTestCase.php
@@ -8,6 +8,7 @@ use Orchestra\Testbench\TestCase;
 use Stillat\Dagger\Compiler\ComponentState;
 use Stillat\Dagger\Exceptions\Mapping\LineMapper;
 use Stillat\Dagger\Facades\Compiler;
+use Stillat\Dagger\Parser\ComponentCache;
 use Stillat\Dagger\Parser\ComponentParser;
 use Stillat\Dagger\ServiceProvider;
 
@@ -58,7 +59,7 @@ class CompilerTestCase extends TestCase
 
     protected function parseComponent(string $template): ComponentState
     {
-        $parser = new ComponentParser;
+        $parser = new ComponentParser(new ComponentCache);
         $parser->setComponentNamespaces(['c']);
 
         return $parser->parse(null, $template, 'random');


### PR DESCRIPTION
Introduces a new internal component model cache, helping to improve performance of heavily reused components during compilation. This cache prevents re-parsing and analysis of components when used multiple times during the compilation process:

```blade
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
<c-alert type="info" message="the message" />
...
```

* This cache _only_ applies to the compiler's internal component model and does not cache the execution of components at runtime
* Cached component models do not persist to disk
* Cached component models are cleared after the current request