### PR TITLE
Improves compatibility with Volt

### DIFF
--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -564,7 +564,8 @@ PHP;
             $compiledComponentTemplate = Str::swap($swapVars, $compiledComponentTemplate);
             $compiledComponentTemplate = $this->compileExceptions($compiledComponentTemplate);
 
-            $compiled .= $compiledComponentTemplate;
+            $compiled .= $this->storeComponentBlock($compiledComponentTemplate);
+
             $this->stopCompilingComponent();
         }
 

--- a/src/Runtime/ViewManifest.php
+++ b/src/Runtime/ViewManifest.php
@@ -3,6 +3,7 @@
 namespace Stillat\Dagger\Runtime;
 
 use Illuminate\Contracts\View\View;
+use Illuminate\Support\Str;
 
 class ViewManifest
 {
@@ -121,6 +122,10 @@ class ViewManifest
 
     public function getStoragePath(string $rootView): string
     {
+        $rootView = Str::swap([
+            ':' => '_',
+        ], $rootView);
+
         return $this->cachePath."_compiler_manifest_{$rootView}.json";
     }
 

--- a/tests/Compiler/AttributeForwardingTest.php
+++ b/tests/Compiler/AttributeForwardingTest.php
@@ -64,13 +64,11 @@ Component B Start
 
 
 
-
 The First Button
 
 The Second Button
 
 The Third Button
-
 
 No Title
 

--- a/tests/Compiler/DynamicComponentsTest.php
+++ b/tests/Compiler/DynamicComponentsTest.php
@@ -139,13 +139,11 @@ Component B Start
 
 
 
-
 The First Button
 
 The Second Button
 
 The Third Button
-
 
 No Title
 


### PR DESCRIPTION
The Volt pre-compiler can aggressively remove `<?php ... ?>` blocks. This is problematic for Dagger since it in-lines nested components.

This change utilizes raw component blocks to hide PHP contents from other pre-compilers.