### PR TITLE
[1.1] Cache attribute

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Adds a `#cache` compiler attribute, which may be used to cache the results of any Dagger component
+- Bumps the minimum Laravel version to `11.23`, for `Cache::flexible` support
+
 ## [v1.0.6](https://github.com/Stillat/dagger/compare/v1.0.5...v1.0.6) - 2025-01-31
 
 - Corrects an issue where Blade stack compilation results in array index errors

--- a/README.md
+++ b/README.md
@@ -44,6 +44,10 @@ The main visual difference when working with Dagger components is the use of the
   - [Shorthand Validation Rules](#shorthand-validation-rules)
 - [Compiler Attributes](#compiler-attributes)
   - [Escaping Compiler Attributes](#escaping-compiler-attributes)
+- [Caching Components](#caching-components)
+  - [Dynamic Cache Keys](#dynamic-cache-keys)
+  - [Specifying the Cache Store](#specifying-the-cache-store)
+  - [Stale While Revalidate/Flexible Caching](#stale-while-revalidate-flexible-cache)
 - [Component Name](#component-name)
 - [Component Depth](#component-depth)
 - [Attribute Forwarding](#attribute-forwarding)
@@ -657,6 +661,97 @@ In general, you should avoid using props or attributes beginning with `#` as the
 - `#classdef`
 - `#cache`
 - `#precompile`
+
+## Caching Components
+
+You may cache the output of any Dagger component using the `#cache` compiler attribute. This attribute utilizes Laravel's [Cache](https://laravel.com/docs/cache) feature, and provides ways to customize cache keys, expirations, and the cache store.
+
+For example, imagine we had a report component that we'd like to cache:
+
+```blade
+<!-- /resources/dagger/views/report.blade.php -->
+
+@php
+    // Some expensive report logic.
+@endphp
+```
+
+Instead of manually capturing output, or adding caching in other locations, we can simply cache the output of our component call like so:
+
+```blade
+<c-report #cache="the-cache-key" />
+```
+
+Now, the output of the component will be cached forever using the `the-cache-key` string as the cache key.
+
+We may also specify a different time-to-live by specifying the number of seconds the cached output is valid:
+
+```blade
+<c-report #cache.300="the-cache-key" />
+```
+
+You may also use a shorthand notation to calculate the time-to-live in seconds. For example, if we'd like to have the cache expire ten minutes from the time the component was first rendered we could use the value `10m`:
+
+```blade
+<c-report
+    #cache.10m="the-cache-key"
+/>
+```
+
+Alternatively, we could also have the cache expire in 1 hour, 15 minutes, and 32 seconds:
+
+```blade
+<c-report
+    #cache=1h15m32s="the-cache-key"
+/>
+```
+
+The total number of seconds is calculated dynamically by adding the desired "date parts" to the current time and *then* calculating the number of seconds to use.
+
+The following table lists the possible suffixes that may be used:
+
+| Suffix | Description | Example |
+|---|---|---|
+| y | Year | 1y |
+| mo | Month | 1mo |
+| w | Week | 1w |
+| d | Day | 2d |
+| h | Hour | 1h |
+| m | Minute | 30m |
+| s | Seconds | 15s |
+
+### Dynamic Cache Keys
+
+You may create dynamic cache keys by prefixing the `#cache` attribute with the `:` character:
+
+```blade
+<c-profile
+    :$user
+    :#cache.forever="'user-profile'.$user->id"
+/>
+```
+
+### Specifying the Cache Store
+
+You may use a specific cache store by providing the desired cache store's name as the final modifier to the `#cache` attribute.
+
+The following examples would cache the output for 30 seconds on different cache stores:
+
+```blade
+<c-first_component #cache.300.array="first-key" />
+
+<c-second_component #cache.300.file="second-key" />
+```
+
+### Stale While Revalidate (Flexible Cache)
+
+You may leverage Laravel's [stale-while-revalidate pattern implementation](https://laravel.com/docs/11.x/cache#swr) using the `flexible` cache modifier. This modifier accepts two values: the number of seconds the cache is considered fresh, and the second value determines how long the cached contents can be served as stale before recalculation is necessary.
+
+```blade
+<c-report
+    #cache.flexible:5:10="the-cache-key"
+/>
+```
 
 ## Component Name
 

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "laravel/framework": "^11.9",
+        "laravel/framework": "^11.23",
         "stillat/blade-parser": "^1.10.3",
         "nikic/php-parser": "^5",
         "symfony/var-exporter": "^6.0"

--- a/composer.json
+++ b/composer.json
@@ -15,13 +15,13 @@
         }
     },
     "require": {
-        "laravel/framework": "^11.24",
+        "laravel/framework": "^11.23",
         "stillat/blade-parser": "^1.10.3",
         "nikic/php-parser": "^5",
         "symfony/var-exporter": "^6.0"
     },
     "require-dev": {
-        "orchestra/testbench": "^9.0",
+        "orchestra/testbench": "^9.2",
         "brianium/paratest": "*",
         "pestphp/pest": "^2",
         "laravel/pint": "^1.13",

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
         }
     },
     "require": {
-        "laravel/framework": "^11.23",
+        "laravel/framework": "^11.24",
         "stillat/blade-parser": "^1.10.3",
         "nikic/php-parser": "^5",
         "symfony/var-exporter": "^6.0"

--- a/src/Cache/CacheAttributeParser.php
+++ b/src/Cache/CacheAttributeParser.php
@@ -1,0 +1,118 @@
+<?php
+
+namespace Stillat\Dagger\Cache;
+
+use Illuminate\Support\Str;
+
+class CacheAttributeParser
+{
+    protected static function parseDurationIntoParts(string $duration): int|array
+    {
+        $duration = strtolower(trim($duration));
+
+        $pattern = '/(\d+)(y|mo|w|d|h|m|s)/';
+
+        preg_match_all($pattern, $duration, $matches, PREG_SET_ORDER);
+
+        $years = 0;
+        $months = 0;
+        $weeks = 0;
+        $days = 0;
+        $hours = 0;
+        $minutes = 0;
+        $seconds = 0;
+
+        foreach ($matches as $match) {
+            $value = (int) $match[1];
+            $unit = $match[2];
+
+            switch ($unit) {
+                case 'y':
+                    $years += $value;
+                    break;
+                case 'mo':
+                    $months += $value;
+                    break;
+                case 'w':
+                    $weeks += $value;
+                    break;
+                case 'd':
+                    $days += $value;
+                    break;
+                case 'h':
+                    $hours += $value;
+                    break;
+                case 'm':
+                    $minutes += $value;
+                    break;
+                case 's':
+                    $seconds += $value;
+                    break;
+            }
+        }
+
+        return [
+            $years,
+            $months,
+            $weeks,
+            $days,
+            $hours,
+            $minutes,
+            $seconds,
+        ];
+    }
+
+    protected static function getDuration(array $parts): string|array
+    {
+        $duration = trim($parts[1] ?? 'forever');
+
+        if ($duration === 'forever') {
+            return $duration;
+        }
+
+        if (Str::contains($duration, ':')) {
+            $durationParts = explode(':', $duration);
+            $duration = array_shift($durationParts);
+
+            return [
+                $duration,
+                array_values($durationParts),
+            ];
+        }
+
+        if (is_numeric($duration)) {
+            return $duration;
+        }
+
+        return [static::parseDurationIntoParts($duration), []];
+    }
+
+    protected static function getStore(array $parts)
+    {
+        return $parts[2] ?? cache()->getDefaultDriver();
+    }
+
+    public static function parseCacheString(string $cache): CacheProperties
+    {
+        if (! Str::startsWith($cache, 'cache.') && $cache !== 'cache') {
+            $cache = 'cache.'.$cache;
+        }
+
+        $parts = explode('.', $cache);
+
+        $extraArgs = [];
+        $store = static::getStore($parts);
+        $duration = static::getDuration($parts);
+
+        if (is_array($duration)) {
+            $extraArgs = $duration[1];
+            $duration = $duration[0];
+        }
+
+        return new CacheProperties(
+            $duration,
+            $store,
+            $extraArgs
+        );
+    }
+}

--- a/src/Cache/CacheProperties.php
+++ b/src/Cache/CacheProperties.php
@@ -1,0 +1,13 @@
+<?php
+
+namespace Stillat\Dagger\Cache;
+
+class CacheProperties
+{
+    public function __construct(
+        public string|array $duration,
+        public string $store,
+        public array $args = [],
+        public string $key = '',
+    ) {}
+}

--- a/src/Compiler/ComponentState.php
+++ b/src/Compiler/ComponentState.php
@@ -5,6 +5,7 @@ namespace Stillat\Dagger\Compiler;
 use Illuminate\View\ComponentAttributeBag;
 use InvalidArgumentException;
 use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\Dagger\Cache\CacheProperties;
 use Stillat\Dagger\Support\Utils;
 
 class ComponentState
@@ -63,6 +64,8 @@ class ComponentState
     public string $validationMessages = '[]';
 
     public int $lineOffset = 0;
+
+    public ?CacheProperties $cacheProperties = null;
 
     public function __construct(
         public ?ComponentNode $node,

--- a/src/Compiler/Concerns/AppliesCompilerParams.php
+++ b/src/Compiler/Concerns/AppliesCompilerParams.php
@@ -19,6 +19,10 @@ trait AppliesCompilerParams
 
     protected function isValidCompilerParam(ParameterNode $param): bool
     {
+        if ($this->isCacheParam($param)) {
+            return true;
+        }
+
         if (in_array($param->type, $this->invalidCompilerParamTypes, true)) {
             return false;
         }
@@ -37,6 +41,14 @@ trait AppliesCompilerParams
     {
         if (count($compilerParams) === 0) {
             return;
+        }
+
+        $cacheParam = collect($compilerParams)
+            ->where(fn (ParameterNode $param) => $this->isCacheParam($param))
+            ->first();
+
+        if ($cacheParam) {
+            $this->applyCacheParam($component, $cacheParam);
         }
 
         $compilerParams = collect($compilerParams)

--- a/src/Compiler/Concerns/CompilesCache.php
+++ b/src/Compiler/Concerns/CompilesCache.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace Stillat\Dagger\Compiler\Concerns;
+
+use Illuminate\Support\Str;
+use Stillat\BladeParser\Nodes\Components\ParameterNode;
+use Stillat\BladeParser\Nodes\Components\ParameterType;
+use Stillat\Dagger\Cache\CacheAttributeParser;
+use Stillat\Dagger\Compiler\ComponentState;
+use Stillat\Dagger\Support\Utils;
+
+trait CompilesCache
+{
+    protected function isCacheParam(ParameterNode $param): bool
+    {
+        return $param->materializedName === '#cache' || Str::startsWith($param->materializedName, '#cache.');
+    }
+
+    protected function applyCacheParam(ComponentState $component, ParameterNode $cacheParam): void
+    {
+        $cacheString = $cacheParam->materializedName;
+
+        if (Str::startsWith($cacheString, '#')) {
+            $cacheString = ltrim($cacheString, '#');
+        }
+
+        $cacheProperties = CacheAttributeParser::parseCacheString($cacheString);
+
+        if (is_array($cacheProperties->duration)) {
+            $now = now()->clone();
+            $expires = $now->clone()
+                ->addYears($cacheProperties->duration[0])
+                ->addMonths($cacheProperties->duration[1])
+                ->addWeeks($cacheProperties->duration[2])
+                ->addDays($cacheProperties->duration[3])
+                ->addHours($cacheProperties->duration[4])
+                ->addMinutes($cacheProperties->duration[5])
+                ->addSeconds($cacheProperties->duration[6]);
+
+            $cacheProperties->duration = $now->diffInSeconds($expires);
+        }
+
+        // TODO: INteroplated variables test.
+        if ($cacheParam->type == ParameterType::DynamicVariable) {
+            $cacheProperties->key = $cacheParam->value;
+        } else {
+            $cacheProperties->key = $cacheParam->valueNode->content;
+        }
+
+        $component->cacheProperties = $cacheProperties;
+    }
+
+    protected function compileCache(string $compiledComponent): string
+    {
+        if ($this->activeComponent->cacheProperties->duration === 'flexible') {
+            $cacheStub = <<<'PHP'
+<?php
+$__cacheKeyVarSuffix = '#key#';
+$__cacheTmpVarsVarSuffix = get_defined_vars();
+
+echo cache()->store('#store#')->flexible($__cacheKeyVarSuffix, [$fresh, $stale], function () use ($__cacheTmpVarsVarSuffix) {
+extract($__cacheTmpVarsVarSuffix);
+ob_start();
+?>#compiled#<?php
+    return ob_get_clean();
+});
+unset($__cacheKeyVarSuffix, $__cacheTmpVars);
+?>
+PHP;
+
+            $cacheStub = Str::swap([
+                '$fresh' => $this->activeComponent->cacheProperties->args[0],
+                '$stale' => $this->activeComponent->cacheProperties->args[1],
+            ], $cacheStub);
+
+        } else {
+            $cacheStub = <<<'PHP'
+<?php
+$__cacheKeyVarSuffix = '#key#';
+
+if (cache()->store('#store#')->has($__cacheKeyVarSuffix)) {
+    echo cache()->store('#store#')->get($__cacheKeyVarSuffix);
+    unset($__cacheKeyVarSuffix);
+} else { ob_start();
+?>#compiled#<?php
+    $__cacheResultVarSuffix = ob_get_clean();
+    #cacheMethod#
+    echo $__cacheResultVarSuffix;
+    unset($__cacheKeyVarSuffix, $__cacheKeyVarSuffix);
+}
+?>
+PHP;
+
+            if ($this->activeComponent->cacheProperties->duration === 'forever') {
+                $cacheMethod = <<<'PHP'
+cache()->store('#store#')->forever($__cacheKeyVarSuffix, $__cacheResultVarSuffix);
+PHP;
+            } else {
+                $cacheMethod = <<<'PHP'
+cache()->store('#store#')->put($__cacheKeyVarSuffix, $__cacheResultVarSuffix, '#ttl#');
+PHP;
+
+                $cacheMethod = Str::swap([
+                    "'#ttl#'" => $this->activeComponent->cacheProperties->duration,
+                ], $cacheMethod);
+            }
+
+            $cacheStub = Str::swap([
+                '#cacheMethod#' => $cacheMethod,
+            ], $cacheStub);
+        }
+
+        return Str::swap([
+            'VarSuffix' => Utils::makeRandomString(),
+            '#store#' => $this->activeComponent->cacheProperties->store,
+            "'#key#'" => $this->activeComponent->cacheProperties->key,
+            '#compiled#' => $compiledComponent,
+        ], $cacheStub);
+    }
+}

--- a/src/Compiler/Concerns/CompilesCache.php
+++ b/src/Compiler/Concerns/CompilesCache.php
@@ -40,7 +40,6 @@ trait CompilesCache
             $cacheProperties->duration = $now->diffInSeconds($expires);
         }
 
-        // TODO: INteroplated variables test.
         if ($cacheParam->type == ParameterType::DynamicVariable) {
             $cacheProperties->key = $cacheParam->value;
         } else {

--- a/src/Compiler/Concerns/CompilesForwardedAttributes.php
+++ b/src/Compiler/Concerns/CompilesForwardedAttributes.php
@@ -16,6 +16,12 @@ trait CompilesForwardedAttributes
         $paramsToKeep = [];
 
         foreach ($node->parameters as $param) {
+            if ($this->isCacheParam($param)) {
+                $compilerParams[] = $param;
+
+                continue;
+            }
+
             if (Str::startsWith($param->name, '##')) {
                 $param->name = mb_substr($param->name, 1);
                 $paramsToKeep[] = $param;

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -15,6 +15,7 @@ use Stillat\BladeParser\Nodes\LiteralNode;
 use Stillat\BladeParser\Parser\DocumentParser;
 use Stillat\Dagger\Compiler\Concerns\AppliesCompilerParams;
 use Stillat\Dagger\Compiler\Concerns\CompilesBasicComponents;
+use Stillat\Dagger\Compiler\Concerns\CompilesCache;
 use Stillat\Dagger\Compiler\Concerns\CompilesCompilerDirectives;
 use Stillat\Dagger\Compiler\Concerns\CompilesComponentDetails;
 use Stillat\Dagger\Compiler\Concerns\CompilesDynamicComponents;
@@ -40,6 +41,7 @@ final class TemplateCompiler
 
     use AppliesCompilerParams,
         CompilesBasicComponents,
+        CompilesCache,
         CompilesCompilerDirectives,
         CompilesComponentDetails,
         CompilesDynamicComponents,
@@ -564,7 +566,7 @@ PHP;
             $compiledComponentTemplate = Str::swap($swapVars, $compiledComponentTemplate);
             $compiledComponentTemplate = $this->compileExceptions($compiledComponentTemplate);
 
-            $compiled .= $this->storeComponentBlock($compiledComponentTemplate);
+            $compiled .= $this->finalizeCompiledComponent($compiledComponentTemplate);
 
             $this->stopCompilingComponent();
         }
@@ -576,6 +578,15 @@ PHP;
         }
 
         return $compiled;
+    }
+
+    protected function finalizeCompiledComponent(string $compiled): string
+    {
+        if ($this->activeComponent->cacheProperties != null) {
+            $compiled = $this->compileCache($compiled);
+        }
+
+        return $this->storeComponentBlock($compiled);
     }
 
     public function cleanup(): void

--- a/tests/Cache/CacheAttributeTest.php
+++ b/tests/Cache/CacheAttributeTest.php
@@ -109,7 +109,7 @@ EXPECTED;
     $this->assertSame($expected, $this->render($template));
     $this->assertSame($expected, $this->render($template));
     $this->assertSame($expected, $this->render($template));
-})->skip();
+});
 
 test('dynamic cache keys', function () {
     $template = <<<'BLADE'

--- a/tests/Cache/CacheAttributeTest.php
+++ b/tests/Cache/CacheAttributeTest.php
@@ -109,7 +109,7 @@ EXPECTED;
     $this->assertSame($expected, $this->render($template));
     $this->assertSame($expected, $this->render($template));
     $this->assertSame($expected, $this->render($template));
-});
+})->skip();
 
 test('dynamic cache keys', function () {
     $template = <<<'BLADE'

--- a/tests/Cache/CacheAttributeTest.php
+++ b/tests/Cache/CacheAttributeTest.php
@@ -1,0 +1,144 @@
+<?php
+
+use Stillat\Dagger\Tests\CompilerTestCase;
+
+uses(CompilerTestCase::class);
+
+test('basic cache attribute', function () {
+    $template = <<<'BLADE'
+@for ($i = 0; $i < 5; $i++)
+<c-cache_attribute.basic
+    #cache.30m="key"
+    title="The Title"
+/>
+@endfor
+BLADE;
+
+    $expected = <<<'EXPECTED'
+Title: The Title
+Var: 1
+
+Title: The Title
+Var: 1
+
+Title: The Title
+Var: 1
+
+Title: The Title
+Var: 1
+
+Title: The Title
+Var: 1
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+});
+
+test('forever cache attribute', function () {
+    $template = <<<'BLADE'
+@for ($i = 0; $i < 5; $i++)
+<c-cache_attribute.basic
+    #cache.forever="key"
+    title="The Title2"
+/>
+@endfor
+BLADE;
+
+    $expected = <<<'EXPECTED'
+Title: The Title2
+Var: 1
+
+Title: The Title2
+Var: 1
+
+Title: The Title2
+Var: 1
+
+Title: The Title2
+Var: 1
+
+Title: The Title2
+Var: 1
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+});
+
+test('flexible cache attribute', function () {
+    $template = <<<'BLADE'
+@for ($i = 0; $i < 5; $i++)
+<c-cache_attribute.basic
+    #cache.flexible:10:20="key"
+    title="The Title3"
+/>
+@endfor
+BLADE;
+
+    $expected = <<<'EXPECTED'
+Title: The Title3
+Var: 1
+
+Title: The Title3
+Var: 1
+
+Title: The Title3
+Var: 1
+
+Title: The Title3
+Var: 1
+
+Title: The Title3
+Var: 1
+EXPECTED;
+
+    $compiled = $this->compile($template);
+
+    $this->assertStringContainsString(
+        "echo cache()->store('array')->flexible(",
+        $compiled
+    );
+
+    $this->assertStringContainsString(
+        ', [10, 20], function ()',
+        $compiled,
+    );
+
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+});
+
+test('dynamic cache keys', function () {
+    $template = <<<'BLADE'
+@for ($i = 0; $i < 5; $i++)
+<c-cache_attribute.basic
+    :#cache.forever="'key'.$i"
+    title="The Title4"
+/>
+@endfor
+BLADE;
+
+    $expected = <<<'EXPECTED'
+Title: The Title4
+Var: 1
+
+Title: The Title4
+Var: 2
+
+Title: The Title4
+Var: 3
+
+Title: The Title4
+Var: 4
+
+Title: The Title4
+Var: 5
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+});

--- a/tests/Cache/CacheAttributeTest.php
+++ b/tests/Cache/CacheAttributeTest.php
@@ -142,3 +142,35 @@ EXPECTED;
     $this->assertSame($expected, $this->render($template));
     $this->assertSame($expected, $this->render($template));
 });
+
+test('dynamic cache keys using interpolation', function () {
+    $template = <<<'BLADE'
+@for ($i = 0; $i < 5; $i++)
+<c-cache_attribute.basic
+    #cache.forever="cache-key-{{ $i }}"
+    title="The Title4"
+/>
+@endfor
+BLADE;
+
+    $expected = <<<'EXPECTED'
+Title: The Title4
+Var: 1
+
+Title: The Title4
+Var: 2
+
+Title: The Title4
+Var: 3
+
+Title: The Title4
+Var: 4
+
+Title: The Title4
+Var: 5
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+    $this->assertSame($expected, $this->render($template));
+});

--- a/tests/Cache/CacheParserTest.php
+++ b/tests/Cache/CacheParserTest.php
@@ -1,0 +1,156 @@
+<?php
+
+use Stillat\Dagger\Cache\CacheAttributeParser;
+use Stillat\Dagger\Tests\CompilerTestCase;
+
+uses(CompilerTestCase::class);
+
+test('it parses cache details', function ($cacheString, $results) {
+    $attributeParser = new CacheAttributeParser;
+
+    $expectedDuration = $results[0];
+    $expectedStore = $results[1];
+    $expectedExtraParams = $results[2];
+
+    $parseResults = $attributeParser->parseCacheString($cacheString);
+
+    expect($parseResults->duration)->toBe($expectedDuration)
+        ->and($parseResults->store)->toBe($expectedStore)
+        ->and($parseResults->args)->toBe($expectedExtraParams);
+})->with([
+    ['cache', ['forever', 'array', []]],
+    ['cache.forever', ['forever', 'array', []]],
+    ['cache.forever.array', ['forever', 'array', []]],
+    ['forever.array1', ['forever', 'array1', []]],
+    ['forever.array1', ['forever', 'array1', []]],
+    ['flexible:5:10', ['flexible', 'array', ['5', '10']]],
+    ['cache.flexible:5:10', ['flexible', 'array', ['5', '10']]],
+    ['cache.flexible:15:150', ['flexible', 'array', ['15', '150']]],
+    ['cache.100', ['100', 'array', []]],
+    ['100', ['100', 'array', []]],
+    ['100.file', ['100', 'file', []]],
+    ['cache.100.file', ['100', 'file', []]],
+    ['42', ['42', 'array', []]],
+    ['42.file', ['42', 'file', []]],
+    ['cache.42.file', ['42', 'file', []]],
+    [
+        'cache.1y.file',
+        [
+            [1, 0, 0, 0, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.2mo.file',
+        [
+            [0, 2, 0, 0, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.3w.file',
+        [
+            [0, 0, 3, 0, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.4d.file',
+        [
+            [0, 0, 0, 4, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.5h.file',
+        [
+            [0, 0, 0, 0, 5, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.6m.file',
+        [
+            [0, 0, 0, 0, 0, 6, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.7s.file',
+        [
+            [0, 0, 0, 0, 0, 0, 7],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo.file',
+        [
+            [1, 2, 0, 0, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo3w.file',
+        [
+            [1, 2, 3, 0, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo3w4d.file',
+        [
+            [1, 2, 3, 4, 0, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo3w4d5h.file',
+        [
+            [1, 2, 3, 4, 5, 0, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo3w4d5h6m.file',
+        [
+            [1, 2, 3, 4, 5, 6, 0],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1y2mo3w4d5h6m7s.file',
+        [
+            [1, 2, 3, 4, 5, 6, 7],
+            'file',
+            [],
+        ],
+    ],
+    [
+        'cache.1d2h3m4s.file',
+        [
+            [0, 0, 0, 1, 2, 3, 4],
+            'file',
+            [],
+        ],
+    ],
+    [
+        '1y2mo3w4d5h6m7s.database',
+        [
+            [1, 2, 3, 4, 5, 6, 7],
+            'database',
+            [],
+        ],
+    ],
+]);

--- a/tests/resources/components/cache_attribute/basic.blade.php
+++ b/tests/resources/components/cache_attribute/basic.blade.php
@@ -1,0 +1,4 @@
+@props(['title'])
+
+Title: {{ $title }}
+Var: {{ \Stillat\Dagger\Tests\StaticTestHelpers::counter() }}


### PR DESCRIPTION
Adds ` #cache` compiler attribute that can be used to cache the results of any Dagger component:

```blade
<c-report #cache.forever="the-cache-key" />
```