### PR TITLE
[1.1] Circular component compilation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Adds compiler support for circular component references, like nested comment threads
+
 ## [v1.0.6](https://github.com/Stillat/dagger/compare/v1.0.5...v1.0.6) - 2025-01-31
 
 - Corrects an issue where Blade stack compilation results in array index errors

--- a/README.md
+++ b/README.md
@@ -108,10 +108,6 @@ Dagger components are also interopable with Blade components, and will add thems
 
 This is due to the View Manifest. The Dagger compiler and runtime will store which component files were used to create the final output in a JSON file, which is later used for cache-invalidation. The Dagger compiler inlines component templates, which prevents typical file-based cache invalidation from working; the View Manifest solves that problem.
 
-### Are circular component hierarchies supported?
-
-A circular component hierarchy is one where Component A includes Component B, which might conditionally include Component A again. Because the compiler inlines components, circular components are not supported and may result in infinite loops.
-
 ### Why build all of this?
 
 Because I wanted to.

--- a/src/Compiler/Concerns/CompilesComponentDetails.php
+++ b/src/Compiler/Concerns/CompilesComponentDetails.php
@@ -33,6 +33,22 @@ trait CompilesComponentDetails
         throw new InvalidArgumentException('Cannot register [x] as a component prefix.');
     }
 
+    protected function getComponentHash(ComponentNode $node): string
+    {
+        $value = $node->content;
+
+        if ($node->isClosedBy != null) {
+            $value .= $node->innerDocumentContent;
+        }
+
+        return md5($value);
+    }
+
+    protected function getComponentName(ComponentNode $node): string
+    {
+        return "{$node->componentPrefix}:{$node->tagName}";
+    }
+
     /**
      * @throws InvalidArgumentException
      */

--- a/src/Compiler/ParameterFactory.php
+++ b/src/Compiler/ParameterFactory.php
@@ -2,10 +2,11 @@
 
 namespace Stillat\Dagger\Compiler;
 
+use Stillat\BladeParser\Nodes\Components\ParameterFactory as BladeParameterFactory;
 use Stillat\BladeParser\Nodes\Components\ParameterNode;
 use Stillat\BladeParser\Nodes\Components\ParameterType;
 
-class ParameterFactory
+class ParameterFactory extends BladeParameterFactory
 {
     public static function makeVariableReference(string $variableName, string $value): ParameterNode
     {

--- a/tests/Compiler/CircularComponentsTest.php
+++ b/tests/Compiler/CircularComponentsTest.php
@@ -1,0 +1,117 @@
+<?php
+
+use Stillat\Dagger\Tests\CompilerTestCase;
+
+uses(CompilerTestCase::class);
+
+test('it compiles circular component references', function () {
+    $comments = [
+        ['message' => 'Message 1'],
+        ['message' => 'Message 2'],
+        [
+            'message' => 'Message 3',
+            'comments' => [
+                ['message' => 'Message 3.1'],
+                [
+                    'message' => 'Message 3.2',
+                    'comments' => [
+                        ['message' => 'Message 3.2.1'],
+                        ['message' => 'Message 3.2.2'],
+                        [
+                            'message' => 'Message 3.2.3',
+                            'comments' => [
+                                ['message' => 'Message 3.2.3.1'],
+                                ['message' => 'Message 3.2.3.2'],
+                                ['message' => 'Message 3.2.3.3'],
+                            ],
+                        ],
+                    ],
+                ],
+                ['message' => 'Message 3.3'],
+            ],
+        ],
+    ];
+
+    $template = <<<'BLADE'
+<c-thread :$comments />
+BLADE;
+
+    $expected = <<<'EXPECTED'
+<ul>
+            
+
+<li>
+    <span>Message 1</span>
+
+    </li>            
+
+<li>
+    <span>Message 2</span>
+
+    </li>            
+
+<li>
+    <span>Message 3</span>
+
+            
+
+<ul>
+            
+
+<li>
+    <span>Message 3.1</span>
+
+    </li>            
+
+<li>
+    <span>Message 3.2</span>
+
+            
+
+<ul>
+            
+
+<li>
+    <span>Message 3.2.1</span>
+
+    </li>            
+
+<li>
+    <span>Message 3.2.2</span>
+
+    </li>            
+
+<li>
+    <span>Message 3.2.3</span>
+
+            
+
+<ul>
+            
+
+<li>
+    <span>Message 3.2.3.1</span>
+
+    </li>            
+
+<li>
+    <span>Message 3.2.3.2</span>
+
+    </li>            
+
+<li>
+    <span>Message 3.2.3.3</span>
+
+    </li>    </ul>    </li>    </ul>    </li>            
+
+<li>
+    <span>Message 3.3</span>
+
+    </li>    </ul>    </li>    </ul>
+EXPECTED;
+
+    $this->assertSame(
+        $expected,
+        $this->render($template, ['comments' => $comments])
+    );
+});

--- a/tests/resources/components/thread/comment.blade.php
+++ b/tests/resources/components/thread/comment.blade.php
@@ -1,0 +1,9 @@
+@props(['comment'])
+
+<li>
+    <span>{{ $comment['message'] }}</span>
+
+    @if (isset($comment['comments']) && count($comment['comments']) > 0)
+        <c-thread :comments="$comment['comments']" />
+    @endif
+</li>

--- a/tests/resources/components/thread/index.blade.php
+++ b/tests/resources/components/thread/index.blade.php
@@ -1,0 +1,7 @@
+@props(['comments'])
+
+<ul>
+    @foreach ($comments as $comment)
+        <c-thread.comment :$comment />
+    @endforeach
+</ul>


### PR DESCRIPTION
This PR adds support for circular component references. An example of this scenario is nested comment threads.