### PR TITLE
Improve compatibility with other component compilers

### DIFF
--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -181,7 +181,7 @@ final class TemplateCompiler
     /**
      * Replaces all raw placeholders within the provided string.
      */
-    protected function resolveBlocks(string $value): string
+    public function resolveBlocks(string $value): string
     {
         $placeholders = array_keys($this->componentBlocks);
 
@@ -742,7 +742,7 @@ PHP;
 
     protected function storeComponentBlock(string $value): string
     {
-        $placeholder = '__RAW::'.Utils::makeRandomString();
+        $placeholder = '__DAGGER_RAW::'.Utils::makeRandomString();
         $this->componentBlocks[$placeholder] = $value;
 
         return $placeholder;

--- a/src/Facades/Compiler.php
+++ b/src/Facades/Compiler.php
@@ -16,6 +16,7 @@ use Stillat\Dagger\Compiler\TemplateCompiler;
  * @method static bool compiledDynamicComponentExists(string $proxyName, string $componentName)
  * @method static void compileDynamicComponent(array $proxyDetails, string $componentName)
  * @method static CompilerOptions getOptions()
+ * @method static resolveBlocks(string $value): string
  * @method static cleanup()
  */
 class Compiler extends Facade

--- a/src/Listeners/ResponsePreparedListener.php
+++ b/src/Listeners/ResponsePreparedListener.php
@@ -17,6 +17,7 @@ class ResponsePreparedListener
     public function handle()
     {
         Compiler::cleanup();
+        ViewCreatingListener::clearCheckedViews();
 
         foreach ($this->manifest->getTracked() as $rootView => $tracked) {
             file_put_contents(


### PR DESCRIPTION
This PR aims to improve compatibility with other component compilers. Some compilers may make use of `Blade::render`, which can have *interesting* side effects with Dagger. This is because Dagger will remove some blocks during the compilation process; the changes here work to detect these calls and adjust the stored compiled output used by `Blade::render`.

A future improvement to this may include some PRs to Laravel, allowing people to run callbacks after render, or after the Blade compilation step itself.