### PR TITLE
New Compiler Attributes and Fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## [v1.3.0]
+
+- Adds support for the `#when` compiler attribute to conditionally render Dagger components
+- Adds support for the `#for` compiler attribute to render a component for each item in a list
+- Improves internal compiler hot reloading behavior when using tools such as Vite
+- Adds a new `hasSlot` helper method to components
+- Adds a new `hasDefaultSlot` helper method to components
+
 ## [v1.2.0](https://github.com/Stillat/dagger/compare/v1.1.1...v1.2.0) - 2025-02-23
 
 - Enable installation in Laravel 12 projects

--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ The main visual difference when working with Dagger components is the use of the
 - [Component Syntax and the Component Builder](#component-syntax-and-the-component-builder)
   - [Slots](#slots)
     - [Named/Scoped Slots](#namedscoped-slots)
+    - [Checking if Slots Exist](#checking-if-slots-exist)
   - [Custom PHP When Using the Component Function](#custom-php-when-using-the-component-function)
   - [Calling Component Builder Methods](#calling-component-builder-methods)
   - [Renaming the Component Variable](#renaming-the-component-variable)
@@ -43,6 +44,7 @@ The main visual difference when working with Dagger components is the use of the
 - [Property Validation](#property-validation)
   - [Shorthand Validation Rules](#shorthand-validation-rules)
 - [Compiler Attributes](#compiler-attributes)
+  - [Conditionally Rendering Components](#conditionally-rendering-components)
   - [Escaping Compiler Attributes](#escaping-compiler-attributes)
 - [Caching Components](#caching-components)
   - [Dynamic Cache Keys](#dynamic-cache-keys)
@@ -283,7 +285,6 @@ Slot content may be specified like so:
 
 Dagger components also support named or *scoped* slots. Accessing scoped slots is done through the `$slots` variable, which is different from Blade components. This is done to help prevent collisions with variables that may have the same name as desireable slot names.
 
-
 Assuming the following component definition:
 
 ```blade
@@ -313,6 +314,24 @@ You may specify content for each slot like so:
     
     Default Slot Content
 </c-docs.namedslot>
+```
+
+#### Checking if Slots Exist
+
+You may use the `hasSlot` method to determine if the component has a named slot:
+
+```blade
+@if ($component->hasSlot('header'))
+    // The developer provided a named "header" slot.
+@endif
+```
+
+If you'd like to check if default slot content was provided you may use the `hasDefaultSlot()` methoid:
+
+```blade
+@if ($component->hasDefaultSlot())
+    // The developer provided a named "header" slot.
+@endif
 ```
 
 ### Custom PHP When Using the Component Function
@@ -639,6 +658,24 @@ The Dagger compiler introduces the concept of "compiler attributes", which have 
 
 Compiler attribute values **must** be static and **cannot** contain PHP expressions or reference variables.
 
+### Conditionally Rendering Components
+
+You may conditionally render a component by adding the `#when` compiler attribute.
+
+For example, instead of the following:
+
+```blade
+@if ($account->is_past_due)
+    <c-banner ... />
+@endif
+```
+
+We can instead write:
+
+```blade
+<c-banner #when="$account->is_past_due" ... />
+```
+
 ### Escaping Compiler Attributes
 
 If you need to output an attribute beginning with `#`, you may escape compiler attributes by prefixing it with another `#` character:
@@ -649,18 +686,7 @@ If you need to output an attribute beginning with `#`, you may escape compiler a
 <c-nested.component ##id="the-escaped-id-attribute" />
 ```
 
-In general, you should avoid using props or attributes beginning with `#` as they are likely to be further developed upon and made available as an extension point, or may conflict with forwarded attributes. The following list of compiler attributes are currently in use, or are reserved for future internal use:
-
-- `#id`
-- `#name`
-- `#compiler`
-- `#style`
-- `#def`
-- `#group`
-- `#styledef`
-- `#classdef`
-- `#cache`
-- `#precompile`
+In general, you should avoid using props or attributes beginning with `#` as they are likely to be further developed upon and made available as an extension point, or may conflict with forwarded attributes.
 
 ## Caching Components
 

--- a/src/Compiler/ComponentState.php
+++ b/src/Compiler/ComponentState.php
@@ -81,6 +81,10 @@ class ComponentState
 
     public ?CacheProperties $cacheProperties = null;
 
+    public array $compilerAttributes = [];
+
+    public array $injectedProps = [];
+
     public function __construct(
         public ?ComponentNode $node,
         public string $varSuffix,

--- a/src/Compiler/Concerns/AppliesCompilerParams.php
+++ b/src/Compiler/Concerns/AppliesCompilerParams.php
@@ -2,6 +2,7 @@
 
 namespace Stillat\Dagger\Compiler\Concerns;
 
+use Illuminate\Support\Str;
 use Stillat\BladeParser\Nodes\Components\ParameterNode;
 use Stillat\BladeParser\Nodes\Components\ParameterType;
 use Stillat\Dagger\Compiler\ComponentState;
@@ -57,8 +58,22 @@ trait AppliesCompilerParams
                     throw new InvalidCompilerParameterException;
                 }
 
-                return [mb_substr($param->name, 1) => $param->value];
+                $name = mb_substr($param->name, 1);
+                $value = $param->value;
+
+                if (Str::contains($name, '.')) {
+                    $extra = Str::after($name, '.');
+                    $name = Str::before($name, '.');
+                    $value = [
+                        $extra,
+                        $value,
+                    ];
+                }
+
+                return [$name => $value];
             })->all();
+
+        $component->compilerAttributes = $compilerParams;
 
         if (isset($compilerParams['id'])) {
             $component->compilerId = '#'.$compilerParams['id'];

--- a/src/Compiler/Concerns/CompilesCompilerAttributes.php
+++ b/src/Compiler/Concerns/CompilesCompilerAttributes.php
@@ -1,0 +1,107 @@
+<?php
+
+namespace Stillat\Dagger\Compiler\Concerns;
+
+use Illuminate\Support\Str;
+use Stillat\Dagger\Support\Utils;
+
+trait CompilesCompilerAttributes
+{
+    protected function compileForAttribute(array $expression, string $compiledOutput): string
+    {
+        $loopExpression = $expression[0] ?? '';
+        $callback = trim($expression[1] ?? '');
+        $loopParts = explode('.', $loopExpression);
+        $spreadPropValues = false;
+        $injectItem = false;
+
+        $callbackData = '';
+
+        if (! isset($loopParts[1])) {
+            $spreadPropValues = true;
+            $loopParts[1] = '__value';
+        }
+
+        $variable = $loopParts[0];
+        $aliasValue = $loopParts[1];
+
+        if (! Str::startsWith($variable, '$')) {
+            $variable = '$'.$variable;
+        } else {
+            $spreadPropValues = true;
+        }
+
+        if (! Str::startsWith($aliasValue, '$')) {
+            $aliasValue = '$'.$aliasValue;
+        } else {
+            $injectItem = true;
+        }
+
+        if ($callback != '') {
+            $callbackStub = <<<'PHP'
+collect($varName)->mapWithKeys($callback)->all()
+PHP;
+
+            $callbackData = Str::swap([
+                '$varName' => $variable,
+                '$callback' => $callback,
+            ], $callbackStub);
+        }
+
+        if ($injectItem) {
+            $injectName = ltrim($loopParts[1], '$');
+            $this->activeComponent->injectedProps[] = str_replace(
+                'varName', $injectName, "\$componentDataVar['varName'] = \$varName;"
+            );
+        }
+
+        if ($spreadPropValues) {
+            $varName = mb_substr($aliasValue, 1);
+
+            $injection = <<<'PHP'
+foreach ($varName as $__key => $__tmp) {
+    if (! is_string($__key)) { continue; }
+    if (isset($compiledPropNames[$__key])) {
+        $componentDataVar[$__key] = $__tmp;
+    }
+}
+unset($__tmp, $__key);
+PHP;
+
+            $this->activeComponent->injectedProps[] = str_replace('varName', $varName, $injection);
+        }
+
+        $stub = <<<'PHP'
+<?php if (isset($varName)) { $__originalVarNameVarSuffix = $varName; }
+foreach ($data as $varName) :?>#compiled#<?php endforeach;
+if (isset($__originalVarNameVarSuffix)) { $varName = $__originalVarNameVarSuffix; unset($__originalVarNameVarSuffix); }
+?>
+PHP;
+
+        $temp = Str::swap([
+            'VarSuffix' => Utils::makeRandomString(),
+            'VarName' => mb_substr($aliasValue, 1),
+            '$varName' => $aliasValue,
+            '$data' => ($callbackData != '') ? $callbackData : $variable,
+            '#compiled#' => $compiledOutput,
+        ], $stub);
+
+        return $temp;
+    }
+
+    protected function compileCompilerAttributes(string $compiledOutput): string
+    {
+        if (empty($this->activeComponent->compilerAttributes)) {
+            return $compiledOutput;
+        }
+
+        if (isset($this->activeComponent->compilerAttributes['for'])) {
+            $compiledOutput = $this->compileForAttribute(
+                $this->activeComponent->compilerAttributes['for'],
+                $compiledOutput
+            );
+        }
+
+        return $compiledOutput;
+    }
+}

--- a/src/Compiler/Concerns/CompilesCompilerAttributes.php
+++ b/src/Compiler/Concerns/CompilesCompilerAttributes.php
@@ -89,6 +89,18 @@ PHP;
         return $temp;
     }
 
+    protected function compileWhenAttribute(string $expression, string $compiledOutput): string
+    {
+        $whenAttribute = <<<'PHP'
+<?php if ($expression): ?>#compiled#<?php endif; ?>
+PHP;
+
+        return Str::swap([
+            '$expression' => $expression,
+            '#compiled#' => $compiledOutput,
+        ], $whenAttribute);
+    }
+
     protected function compileCompilerAttributes(string $compiledOutput): string
     {
         if (empty($this->activeComponent->compilerAttributes)) {
@@ -99,6 +111,13 @@ PHP;
             $compiledOutput = $this->compileForAttribute(
                 $this->activeComponent->compilerAttributes['for'],
                 $compiledOutput
+            );
+        }
+
+        if (isset($this->activeComponent->compilerAttributes['when'])) {
+            $compiledOutput = $this->compileWhenAttribute(
+                $this->activeComponent->compilerAttributes['when'],
+                $compiledOutput,
             );
         }
 

--- a/src/Compiler/Concerns/CompilesCompilerDirectives.php
+++ b/src/Compiler/Concerns/CompilesCompilerDirectives.php
@@ -69,6 +69,9 @@ PHP;
             if ($this->processCompileIfVar($line, $newLines)) {
                 continue;
             }
+            if ($this->processCompilePlaceholder($line, '/** COMPILE:INJECTED_PROPS', fn () => $this->compileInjectedProps(), $newLines)) {
+                continue;
+            }
             if ($this->processCompilePlaceholder($line, '/** COMPILE:PROPS_DEFAULT', fn () => $this->compileDefaultProps(), $newLines)) {
                 continue;
             }

--- a/src/Compiler/Concerns/CompilesForwardedAttributes.php
+++ b/src/Compiler/Concerns/CompilesForwardedAttributes.php
@@ -16,9 +16,6 @@ trait CompilesForwardedAttributes
         $paramsToKeep = [];
 
         foreach ($node->parameters as $param) {
-            if (Str::contains($node->content, '#each')) {
-                dd('hiasdasd', $param);
-            }
             if ($this->isCacheParam($param) || Str::startsWith($param->materializedName, $this->compilerDirectiveParams)) {
                 $compilerParams[] = $param;
 

--- a/src/Compiler/Concerns/CompilesForwardedAttributes.php
+++ b/src/Compiler/Concerns/CompilesForwardedAttributes.php
@@ -16,7 +16,10 @@ trait CompilesForwardedAttributes
         $paramsToKeep = [];
 
         foreach ($node->parameters as $param) {
-            if ($this->isCacheParam($param)) {
+            if (Str::contains($node->content, '#each')) {
+                dd('hiasdasd', $param);
+            }
+            if ($this->isCacheParam($param) || Str::startsWith($param->materializedName, $this->compilerDirectiveParams)) {
                 $compilerParams[] = $param;
 
                 continue;

--- a/src/Compiler/Concerns/CompilesPhp.php
+++ b/src/Compiler/Concerns/CompilesPhp.php
@@ -32,6 +32,19 @@ trait CompilesPhp
         return '$__componentData = array_intersect_key($__componentData, $compiledPropNames);';
     }
 
+    protected function compileInjectedProps(): string
+    {
+        if (empty($this->activeComponent->injectedProps)) {
+            return '';
+        }
+        $componentDataVar = $this->activeComponent->componentDataVar();
+        $injections = implode($this->newlineStyle, $this->activeComponent->injectedProps);
+
+        return Str::swap([
+            'componentDataVar' => $componentDataVar,
+        ], $injections);
+    }
+
     protected function compileDefaultProps(): string
     {
         $varInitializers = [];

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -181,6 +181,11 @@ final class TemplateCompiler
         return $this->compilerDepth === 0;
     }
 
+    public function getComponentBlocks(): array
+    {
+        return $this->componentBlocks;
+    }
+
     /**
      * Replaces all raw placeholders within the provided string.
      */

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -16,6 +16,7 @@ use Stillat\BladeParser\Parser\DocumentParser;
 use Stillat\Dagger\Compiler\Concerns\AppliesCompilerParams;
 use Stillat\Dagger\Compiler\Concerns\CompilesBasicComponents;
 use Stillat\Dagger\Compiler\Concerns\CompilesCache;
+use Stillat\Dagger\Compiler\Concerns\CompilesCompilerAttributes;
 use Stillat\Dagger\Compiler\Concerns\CompilesCompilerDirectives;
 use Stillat\Dagger\Compiler\Concerns\CompilesComponentDetails;
 use Stillat\Dagger\Compiler\Concerns\CompilesDynamicComponents;
@@ -45,6 +46,7 @@ final class TemplateCompiler
     use AppliesCompilerParams,
         CompilesBasicComponents,
         CompilesCache,
+        CompilesCompilerAttributes,
         CompilesCompilerDirectives,
         CompilesComponentDetails,
         CompilesDynamicComponents,
@@ -60,6 +62,7 @@ final class TemplateCompiler
         '#style', '#def', '#group',
         '#styledef', '#classdef',
         '#cache', '#precomile',
+        '#for',
     ];
 
     protected ReflectionMethod $storeRawBlockProxy;
@@ -273,6 +276,8 @@ final class TemplateCompiler
 
     protected function stopCompilingComponent(): void
     {
+        $this->activeComponent->injectedProps = [];
+
         array_pop($this->componentStack);
         array_pop($this->componentPath);
         array_pop($this->activeComponentNames);
@@ -489,6 +494,7 @@ final class TemplateCompiler
 <?php
 try {
 $__componentData = \Stillat\Dagger\Runtime\Attributes::mergeNestedAttributes($compiledParams, $compiledPropNames);
+/** COMPILE:INJECTED_PROPS */
 /** COMPILE:PROPS_DEFAULT */
 /** COMPILE_IF_VAR:componentGlobalScope $targetVar = get_defined_vars(); */
 $__slotContainerVarSuffix = new \Stillat\Dagger\Runtime\SlotContainer;
@@ -585,6 +591,7 @@ PHP;
                 $this->activeComponent->getGlobalScopeVariableName();
             }
 
+            $compiledComponentTemplate = $this->compileCompilerAttributes($compiledComponentTemplate);
             $compiledComponentTemplate = $this->compileCompilerDirectives($compiledComponentTemplate);
 
             $propNames = array_flip($componentModel->getAllPropNames());

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -62,7 +62,7 @@ final class TemplateCompiler
         '#style', '#def', '#group',
         '#styledef', '#classdef',
         '#cache', '#precomile',
-        '#for',
+        '#for', '#when'
     ];
 
     protected ReflectionMethod $storeRawBlockProxy;

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -62,7 +62,7 @@ final class TemplateCompiler
         '#style', '#def', '#group',
         '#styledef', '#classdef',
         '#cache', '#precomile',
-        '#for', '#when'
+        '#for', '#when',
     ];
 
     protected ReflectionMethod $storeRawBlockProxy;

--- a/src/Facades/Compiler.php
+++ b/src/Facades/Compiler.php
@@ -18,6 +18,7 @@ use Stillat\Dagger\Compiler\TemplateCompiler;
  * @method static CompilerOptions getOptions()
  * @method static resolveBlocks(string $value): string
  * @method static cleanup()
+ * @method static array getComponentBlocks()
  */
 class Compiler extends Facade
 {

--- a/src/Facades/Compiler.php
+++ b/src/Facades/Compiler.php
@@ -9,15 +9,15 @@ use Stillat\Dagger\Compiler\TemplateCompiler;
 /**
  * @method static void addComponentViewPath(string $componentPrefix, string $path)
  * @method static void addComponentPath(string $namespace, string $path)
- * @method static void registerComponentPath(string $componentPrefix, string $path, ?string $namespace = NULL)
+ * @method static void registerComponentPath(string $componentPrefix, string $path, ?string $namespace = null)
  * @method static string compile(string $template)
  * @method static string compileWithLineNumbers(string $template)
  * @method static string getDynamicComponentPath(string $proxyName, string|null $componentName = null)
  * @method static bool compiledDynamicComponentExists(string $proxyName, string $componentName)
  * @method static void compileDynamicComponent(array $proxyDetails, string $componentName)
  * @method static CompilerOptions getOptions()
- * @method static resolveBlocks(string $value): string
- * @method static cleanup()
+ * @method static string resolveBlocks(string $value)
+ * @method static void cleanup()
  * @method static array getComponentBlocks()
  */
 class Compiler extends Facade

--- a/src/Listeners/ViewCreatingListener.php
+++ b/src/Listeners/ViewCreatingListener.php
@@ -46,9 +46,15 @@ class ViewCreatingListener
             return;
         }
 
+        $contents = file_get_contents($path);
+
+        if (! Str::contains($contents, array_keys(Compiler::getComponentBlocks()))) {
+            return;
+        }
+
         file_put_contents(
             $path,
-            Compiler::resolveBlocks(file_get_contents($path))
+            Compiler::resolveBlocks($contents)
         );
     }
 

--- a/src/Runtime/Component.php
+++ b/src/Runtime/Component.php
@@ -133,6 +133,11 @@ class Component extends AbstractComponent
         return $this->slots->hasSlot($slotName);
     }
 
+    public function hasDefaultSlot(): bool
+    {
+        return $this->slots->hasDefaultSlotContent();
+    }
+
     public function __call($method, $parameters)
     {
         if (! isset($this->macros[$method])) {

--- a/src/Runtime/Component.php
+++ b/src/Runtime/Component.php
@@ -128,6 +128,11 @@ class Component extends AbstractComponent
         return $this->macros;
     }
 
+    public function hasSlot(string $slotName): bool
+    {
+        return $this->slots->hasSlot($slotName);
+    }
+
     public function __call($method, $parameters)
     {
         if (! isset($this->macros[$method])) {

--- a/src/Runtime/ViewManifest.php
+++ b/src/Runtime/ViewManifest.php
@@ -17,6 +17,7 @@ class ViewManifest
 
     public function __construct(string $cachePath)
     {
+        ray('CREATING NEW INSTANCE?!');
         $this->cachePath = $cachePath;
     }
 

--- a/src/Runtime/ViewManifest.php
+++ b/src/Runtime/ViewManifest.php
@@ -17,7 +17,6 @@ class ViewManifest
 
     public function __construct(string $cachePath)
     {
-        ray('CREATING NEW INSTANCE?!');
         $this->cachePath = $cachePath;
     }
 

--- a/tests/Compiler/ForAttributeTest.php
+++ b/tests/Compiler/ForAttributeTest.php
@@ -1,0 +1,141 @@
+<?php
+
+use Stillat\Dagger\Tests\CompilerTestCase;
+
+uses(CompilerTestCase::class);
+
+test('for attribute is compiled', function () {
+    $template = <<<'BLADE'
+<ul>
+    <c-for.item #for.items.item :text="$item['text']" />
+</ul>
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1'],
+            ['text' => 'Item 2'],
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li>Item 1</li>
+
+<li>Item 2</li></ul>
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});
+
+test('alias does not leak and stomp over existing data', function () {
+    $template = <<<'BLADE'
+<?php $item = 'Hello, world.'; ?>
+<ul>
+    <c-for.item #for.items.item :text="$item['text']" />
+</ul>
+After: {{ $item }}
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1'],
+            ['text' => 'Item 2'],
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li>Item 1</li>
+
+<li>Item 2</li></ul>
+After: Hello, world.
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});
+
+test('the variable can be injected as a prop', function () {
+
+    $template = <<<'BLADE'
+<ul>
+    <c-for.item_prop #for.items.$item />
+</ul>
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1'],
+            ['text' => 'Item 2'],
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li>Item 1</li>
+
+<li>Item 2</li></ul>
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});
+
+test('variables can be spread into component props', function () {
+
+    $template = <<<'BLADE'
+<ul>
+    <c-for.item_spread #for.items />
+</ul>
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+            ['text' => 'Item 2', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li >Item 1</li>
+
+<li >Item 2</li></ul>
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});
+
+test('variables can be spread into component props using explicit syntax', function () {
+
+    $template = <<<'BLADE'
+<ul>
+    <c-for.item_spread #for.$items.item />
+</ul>
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+            ['text' => 'Item 2', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li >Item 1</li>
+
+<li >Item 2</li></ul>
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});

--- a/tests/Compiler/ForAttributeTest.php
+++ b/tests/Compiler/ForAttributeTest.php
@@ -114,10 +114,35 @@ EXPECTED;
 });
 
 test('variables can be spread into component props using explicit syntax', function () {
-
     $template = <<<'BLADE'
 <ul>
     <c-for.item_spread #for.$items.item />
+</ul>
+BLADE;
+
+    $data = [
+        'items' => [
+            ['text' => 'Item 1', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+            ['text' => 'Item 2', 'id' => 'test-id'], // The id should not leak as an extra attribute.
+        ],
+    ];
+
+    $expected = <<<'EXPECTED'
+<ul>
+    
+
+<li >Item 1</li>
+
+<li >Item 2</li></ul>
+EXPECTED;
+
+    $this->assertSame($expected, $this->render($template, $data));
+});
+
+test('values can be spread using the attribute syntax', function () {
+    $template = <<<'BLADE'
+<ul>
+    <c-for.item_spread #for="$items as ...$item" />
 </ul>
 BLADE;
 

--- a/tests/Compiler/WhenAttributeTest.php
+++ b/tests/Compiler/WhenAttributeTest.php
@@ -1,0 +1,14 @@
+<?php
+
+use Stillat\Dagger\Tests\CompilerTestCase;
+
+uses(CompilerTestCase::class);
+
+test('when attribute is compiled', function () {
+    $blade = <<<'BLADE'
+<c-when.basic #when="$value" title="The Title" />
+BLADE;
+
+    $this->assertSame('', $this->render($blade, ['value' => false]));
+    $this->assertSame('The Title', $this->render($blade, ['value' => true]));
+});

--- a/tests/resources/components/for/item.blade.php
+++ b/tests/resources/components/for/item.blade.php
@@ -1,0 +1,3 @@
+@props(['text'])
+
+<li>{{ $text }}</li>

--- a/tests/resources/components/for/item_prop.blade.php
+++ b/tests/resources/components/for/item_prop.blade.php
@@ -1,0 +1,3 @@
+@props(['item'])
+
+<li>{{ $item['text'] }}</li>

--- a/tests/resources/components/for/item_spread.blade.php
+++ b/tests/resources/components/for/item_spread.blade.php
@@ -1,0 +1,3 @@
+@props(['text'])
+
+<li {{ $attributes }}>{{ $text }}</li>

--- a/tests/resources/components/when/basic.blade.php
+++ b/tests/resources/components/when/basic.blade.php
@@ -1,0 +1,3 @@
+@props(['title'])
+
+{{ $title }}


### PR DESCRIPTION
This PR makes the following changes:

- Adds support for the `#when` compiler attribute to conditionally render Dagger components
- Adds support for the `#for` compiler attribute to render a component for each item in a list
- Improves internal compiler hot reloading behavior when using tools such as Vite
- Adds a new `hasSlot` helper method to components
- Adds a new `hasDefaultSlot` helper method to components