### PR TITLE
Fixed 'stillat/blade-parser' dependency for laravel 12

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
     },
     "require": {
         "laravel/framework": "^11.23 || ^12.0",
-        "stillat/blade-parser": "^1.10.3",
+        "stillat/blade-parser": "^1.10.3 || ^v2.0.0",
         "nikic/php-parser": "^5",
         "symfony/var-exporter": "^6.0"
     },


### PR DESCRIPTION
The component is not installable in Laravel 12 because there is still the dependency to stillat/blade-parser 1.10 which is only compatible with Laravel <=11.
