### PR TITLE
Custom component compiler callbacks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## [v1.4.0](https://github.com/Stillat/dagger/compare/v1.3.1...v1.4.0) - 2025-06-15
+
+- Adds the ability to compile components using a callback function
+
 ## [v1.3.1](https://github.com/Stillat/dagger/compare/v1.3.0...v1.3.1) - 2025-05-07
 
 - Corrects dependencies for Laravel 12 (#28)

--- a/README.md
+++ b/README.md
@@ -79,6 +79,9 @@ The main visual difference when working with Dagger components is the use of the
   - [Disabling Compile Time Rendering on a Component](#disabling-compile-time-rendering-on-a-component)
   - [Enabling/Disabling Optimizations on Classes or Methods](#enablingdisabling-optimizations-on-classes-or-methods)
   - [Notes on Compile Time Rendering](#notes-on-compile-time-rendering)
+- [Component Compiler Callbacks](#component-compiler-callbacks)
+  - [Hanling Inner Content](#handling-inner-content)
+  - [Wildcard Component Patterns](#wildcard-component-patterns)
 - [The View Manifest](#the-view-manifest)
 - [License](#license)
 
@@ -1653,6 +1656,72 @@ class MyAwesomeClass
 
 - You should *never* attempt to force a component to render at compile time, outside of applying the `EnableOptimization` or `DisableOptimization` attributes to your own helper methods
 - If an exception is raised while rendering a component at compile time, CTR will be disabled for that component and the compiler will revert to normal behavior
+
+## Component Compiler Callbacks
+
+There are times you way wish to compile a component *without* a corresponding view file, similar to a directive. This can be accomplished by registering your custom component compiler callback using the `Compiler::compileComponent` method:
+
+```php
+<?php
+
+use Stillat\Dagger\Facades\Compiler;
+
+Compiler::compileComponent('c:mycomponent', function ($node) {
+    return 'My Component';
+});
+
+```
+
+Whenever the `<c-mycomponent />` component is compiled our custom callback will be invoked and that used as the compiled output.
+
+### Handling Inner Content
+
+For component tag pairs, the template compiler will provide the pre-compiled inner content as the second argument to the callback:
+
+```php
+<?php
+
+use Stillat\Dagger\Facades\Compiler;
+
+Compiler::compileComponent('c:mycomponent', function ($node, $innerContent) {
+    return '<div class="simple-wrapper">'.$innerContent.'</div>';
+});
+
+```
+
+This is useful if you would like to wrap the compiled output and not have to manage compiling the inner content yourself:
+
+```blade
+<c-mycomponent>
+    <x-alert title="Other Components" />
+</c-mycomponent>
+```
+
+### Wildcard Component Patterns
+
+You may use wildcards when registering your compiler callbacks:
+
+```php
+```php
+<?php
+
+use Illuminate\Support\Str;
+use Stillat\Dagger\Facades\Compiler;
+
+Compiler::compileComponent('c:stack:*', function ($node) {
+    $stackName = Str::after($node->tagName, ':');
+    
+    // ...
+});
+
+```
+
+Our callback would now be invoked for all of the following:
+
+```blade
+<s-stack:styles />
+<c-stack:scripts />
+```
 
 ## The View Manifest
 

--- a/README.md
+++ b/README.md
@@ -1702,7 +1702,6 @@ This is useful if you would like to wrap the compiled output and not have to man
 You may use wildcards when registering your compiler callbacks:
 
 ```php
-```php
 <?php
 
 use Illuminate\Support\Str;

--- a/src/Compiler/Concerns/ManagesComponentCompilerCallbacks.php
+++ b/src/Compiler/Concerns/ManagesComponentCompilerCallbacks.php
@@ -1,0 +1,71 @@
+<?php
+
+namespace Stillat\Dagger\Compiler\Concerns;
+
+use Closure;
+use Illuminate\Support\Str;
+use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\Dagger\Exceptions\InvalidArgumentException;
+
+trait ManagesComponentCompilerCallbacks
+{
+    protected array $componentCompilers = [];
+
+    public function compileComponent(string $component, Closure $callback): static
+    {
+        $prefix = Str::before($component, ':');
+        $component = Str::after($component, ':');
+
+        if (! $prefix || ! in_array($prefix, $this->componentNamespaces)) {
+            throw new InvalidArgumentException("[$component] must have a registered component prefix.");
+        }
+
+        if (! $component) {
+            throw new InvalidArgumentException("[$component] is not a valid component name.");
+        }
+
+        return $this->compileComponentWithPrefix(
+            $prefix,
+            $component,
+            $callback
+        );
+    }
+
+    public function compileComponentWithPrefix(string $prefix, string $component, Closure $callback): static
+    {
+        if (! array_key_exists($prefix, $this->componentCompilers)) {
+            $this->componentCompilers[$prefix] = [];
+        }
+
+        $this->componentCompilers[$prefix][$component] = $callback;
+
+        return $this;
+    }
+
+    protected function compileComponentCallback(ComponentNode $node): mixed
+    {
+        if (! array_key_exists($node->componentPrefix, $this->componentCompilers)) {
+            return false;
+        }
+
+        /**
+         * @var $pattern
+         * @var Closure $callback
+         */
+        foreach ($this->componentCompilers[$node->componentPrefix] as $pattern => $callback) {
+            if (! Str::is($pattern, $node->tagName)) {
+                continue;
+            }
+
+            ray($pattern);
+
+            return $callback->call(
+                $this,
+                $node,
+                $this->compileNodes($node->childNodes ?? [])
+            );
+        }
+
+        return false;
+    }
+}

--- a/src/Compiler/TemplateCompiler.php
+++ b/src/Compiler/TemplateCompiler.php
@@ -24,6 +24,7 @@ use Stillat\Dagger\Compiler\Concerns\CompilesForwardedAttributes;
 use Stillat\Dagger\Compiler\Concerns\CompilesPhp;
 use Stillat\Dagger\Compiler\Concerns\CompilesSlots;
 use Stillat\Dagger\Compiler\Concerns\CompilesStencils;
+use Stillat\Dagger\Compiler\Concerns\ManagesComponentCompilerCallbacks;
 use Stillat\Dagger\Compiler\Concerns\ManagesComponentCtrState;
 use Stillat\Dagger\Compiler\Concerns\ManagesExceptions;
 use Stillat\Dagger\Exceptions\CompilerException;
@@ -54,6 +55,7 @@ final class TemplateCompiler
         CompilesPhp,
         CompilesSlots,
         CompilesStencils,
+        ManagesComponentCompilerCallbacks,
         ManagesComponentCtrState,
         ManagesExceptions;
 
@@ -400,6 +402,12 @@ final class TemplateCompiler
 
             $currentView = $this->manifest->last();
             $currentViewPath = $currentView?->getPath();
+
+            if ($callbackResult = $this->compileComponentCallback($node)) {
+                $compiled .= $callbackResult;
+
+                continue;
+            }
 
             if ($this->isDynamicComponent($node)) {
                 $compiled .= $this->compileDynamicComponentScaffolding($node, $currentViewPath ?? '');

--- a/src/Facades/Compiler.php
+++ b/src/Facades/Compiler.php
@@ -2,6 +2,7 @@
 
 namespace Stillat\Dagger\Facades;
 
+use Closure;
 use Illuminate\Support\Facades\Facade;
 use Stillat\Dagger\Compiler\CompilerOptions;
 use Stillat\Dagger\Compiler\TemplateCompiler;
@@ -11,6 +12,8 @@ use Stillat\Dagger\Compiler\TemplateCompiler;
  * @method static void addComponentPath(string $namespace, string $path)
  * @method static void registerComponentPath(string $componentPrefix, string $path, ?string $namespace = null)
  * @method static string compile(string $template)
+ * @method static TemplateCompiler compileComponent(string $component, Closure $callback)
+ * @method static TemplateCompiler compileComponentWithPrefix(string $prefix, string $component, Closure $callback)
  * @method static string compileWithLineNumbers(string $template)
  * @method static string getDynamicComponentPath(string $proxyName, string|null $componentName = null)
  * @method static bool compiledDynamicComponentExists(string $proxyName, string $componentName)

--- a/tests/AttributeCache/AttributeForwardingTest.php
+++ b/tests/AttributeCache/AttributeForwardingTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('forwarded attributes can be cached', function () {
     $template = <<<'BLADE'
 <c-cache.root #inner:title="The Title" />

--- a/tests/AttributeCache/DynamicComponentsAttributeForwardingTest.php
+++ b/tests/AttributeCache/DynamicComponentsAttributeForwardingTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('forwarded attributes can be cached inside dynamic components', function () {
     $template = <<<'BLADE'
 <c-dynamic-component component="cache.root" #inner:title="The Title" />

--- a/tests/AttributeCache/DynamicComponentsForwardedSlotsTest.php
+++ b/tests/AttributeCache/DynamicComponentsForwardedSlotsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('forwarded named slots can be cached within dynamic components', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 3; $i++)

--- a/tests/AttributeCache/DynamicComponentsNamedSlotsTest.php
+++ b/tests/AttributeCache/DynamicComponentsNamedSlotsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('dynamic named slot variables bust the cache within dynamic components', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 2; $i++)

--- a/tests/AttributeCache/DynamicComponentsSlotsTest.php
+++ b/tests/AttributeCache/DynamicComponentsSlotsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('it replaces basic slot content within dynamic components', function () {
     $template = <<<'BLADE'

--- a/tests/AttributeCache/ForwardedSlotsTest.php
+++ b/tests/AttributeCache/ForwardedSlotsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('forwarded named slots can be cached', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 3; $i++)

--- a/tests/AttributeCache/NamedSlotsTest.php
+++ b/tests/AttributeCache/NamedSlotsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('dynamic named slot variables bust the cache', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 2; $i++)

--- a/tests/AttributeCache/SlotsTest.php
+++ b/tests/AttributeCache/SlotsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('it replaces basic slot content', function () {
     $template = <<<'BLADE'

--- a/tests/Cache/CacheAttributeTest.php
+++ b/tests/Cache/CacheAttributeTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('basic cache attribute', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 5; $i++)

--- a/tests/Cache/CacheParserTest.php
+++ b/tests/Cache/CacheParserTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Stillat\Dagger\Cache\CacheAttributeParser;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('it parses cache details', function ($cacheString, $results) {
     $attributeParser = new CacheAttributeParser;

--- a/tests/Compiler/AttributeForwardingTest.php
+++ b/tests/Compiler/AttributeForwardingTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('parameters can be forwarded', function () {
     $template = <<<'BLADE'

--- a/tests/Compiler/AttributesTest.php
+++ b/tests/Compiler/AttributesTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it renders attributes', function () {
     $this->assertSame(
         'class="one two three" No Prop',

--- a/tests/Compiler/AwareTest.php
+++ b/tests/Compiler/AwareTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('aware can retrieve default prop value from parent', function () {
     $this->assertSame(
         'Root Default!',

--- a/tests/Compiler/BasicComponentsTest.php
+++ b/tests/Compiler/BasicComponentsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it compiles simple static content', function () {
     $this->assertSame(
         'Some Static Content {{ title }}',

--- a/tests/Compiler/BladeStackCompilerTest.php
+++ b/tests/Compiler/BladeStackCompilerTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it does not trigger errors if it cannot find ending string', function () {
     $input = <<<'PHP'
 @props([

--- a/tests/Compiler/CallbackCompilerTest.php
+++ b/tests/Compiler/CallbackCompilerTest.php
@@ -1,0 +1,67 @@
+<?php
+
+use Stillat\BladeParser\Nodes\Components\ComponentNode;
+use Stillat\Dagger\Exceptions\InvalidArgumentException;
+use Stillat\Dagger\Facades\Compiler;
+
+test('custom compiler callbacks are invoked', function () {
+    $template = <<<'BLADE'
+<c-callback />
+BLADE;
+
+    Compiler::compileComponent('c:callback', function () {
+        return 'Hello, world!';
+    });
+
+    $this->assertSame('Hello, world!', $this->render($template));
+});
+
+test('custom compiler callbacks receive component node instance', function () {
+    $template = <<<'BLADE'
+<c-callback />
+BLADE;
+
+    Compiler::compileComponent('c:callback', function (ComponentNode $node) {
+        return 'Component: '.$node->tagName;
+    });
+
+    $this->assertSame('Component: callback', $this->render($template));
+});
+
+test('custom compiler callbacks can use wildcard patterns', function () {
+    $template = <<<'BLADE'
+<c-callback:name />
+BLADE;
+
+    Compiler::compileComponent('c:callback:*', function (ComponentNode $node) {
+        return 'Component: '.$node->tagName;
+    });
+
+    $this->assertSame('Component: callback:name', $this->render($template));
+});
+
+test('custom compiler component callback receives compiled inner content', function () {
+    $template = <<<'BLADE'
+<c-callback>
+    Content: <c-basic title="The Basic Component" />
+</c-callback>
+BLADE;
+
+    Compiler::compileComponent('c:callback', function (ComponentNode $node, string $innerContent) {
+        return trim($innerContent);
+    });
+
+    $this->assertSame('Content: The Basic Component', $this->render($template));
+});
+
+test('registering a callback for a non-existent component prefix/namespace throws exception', function () {
+    $this->expectException(InvalidArgumentException::class);
+
+    Compiler::compileComponent('thing:callback', fn () => null);
+});
+
+test('registering a callback for an invalid component name throws exception', function () {
+    $this->expectException(InvalidArgumentException::class);
+
+    Compiler::compileComponent('c:', fn () => null);
+});

--- a/tests/Compiler/CircularComponentsTest.php
+++ b/tests/Compiler/CircularComponentsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it compiles circular component references', function () {
     $comments = [
         ['message' => 'Message 1'],

--- a/tests/Compiler/CompilerOutputTest.php
+++ b/tests/Compiler/CompilerOutputTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it trims dynamic output', function () {
     $template = <<<'BLADE'
 <c-output.dynamic_trim />

--- a/tests/Compiler/CompilerParamsTest.php
+++ b/tests/Compiler/CompilerParamsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Stillat\Dagger\Exceptions\InvalidCompilerParameterException;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('it throws an exception when using variable references', function () {
     $this->expectException(InvalidCompilerParameterException::class);

--- a/tests/Compiler/CompleTimeRenderingTest.php
+++ b/tests/Compiler/CompleTimeRenderingTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('simple components can be rendered at compile time', function () {
     $this->assertSame(
         '<button>Book Room</button>',

--- a/tests/Compiler/CustomFunctionsTest.php
+++ b/tests/Compiler/CustomFunctionsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('custom functions in a component are compiled', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 5; $i++)

--- a/tests/Compiler/CustomNamespaceTest.php
+++ b/tests/Compiler/CustomNamespaceTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('custom namespaces can be registered', function () {
     $this->assertSame(
         '<b-test />',

--- a/tests/Compiler/DocsTest.php
+++ b/tests/Compiler/DocsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('alert example', function () {
     $template = <<<'BLADE'
 <c-docs.alert type="error" :message="$message" class="mb-4"/>

--- a/tests/Compiler/DynamicComponentsTest.php
+++ b/tests/Compiler/DynamicComponentsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('it renders dynamic components', function () {
     $template = <<<'BLADE'

--- a/tests/Compiler/ErrorsTest.php
+++ b/tests/Compiler/ErrorsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('invalid template end component triggers error', function () {
     $this->expectExceptionMessage('Compiler component [compiler:template_end] must be the last component.');
 

--- a/tests/Compiler/ForAttributeTest.php
+++ b/tests/Compiler/ForAttributeTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('for attribute is compiled', function () {
     $template = <<<'BLADE'
 <ul>

--- a/tests/Compiler/NamespaceInliningTest.php
+++ b/tests/Compiler/NamespaceInliningTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('class import namespaces are inlined', function () {
     $template = <<<'BLADE'

--- a/tests/Compiler/PropertiesTest.php
+++ b/tests/Compiler/PropertiesTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it parses props directive', function () {
     $template = <<<'BLADE'
 <c-properties.basic title="The Title" class="some class names here" />

--- a/tests/Compiler/RenderFunctionTest.php
+++ b/tests/Compiler/RenderFunctionTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('render function is evaluated for each invocation', function () {
     $template = <<<'BLADE'
 @for ($i = 0; $i < 10; $i++)

--- a/tests/Compiler/SlotForwardingTest.php
+++ b/tests/Compiler/SlotForwardingTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('slots can be forward to nested components', function () {
     $template = <<<'BLADE'

--- a/tests/Compiler/SlotsTest.php
+++ b/tests/Compiler/SlotsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('default slot scope behavior is equivalent to blade components', function () {
     $bladeComponent = <<<'BLADE'

--- a/tests/Compiler/StencilsTest.php
+++ b/tests/Compiler/StencilsTest.php
@@ -1,9 +1,6 @@
 <?php
 
 use Illuminate\Support\Str;
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
 
 test('default stencil content is rendered if not changed', function () {
     $this->assertSame(

--- a/tests/Compiler/WhenAttributeTest.php
+++ b/tests/Compiler/WhenAttributeTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('when attribute is compiled', function () {
     $blade = <<<'BLADE'
 <c-when.basic #when="$value" title="The Title" />

--- a/tests/LineNumbers/BasicLineNumbersTest.php
+++ b/tests/LineNumbers/BasicLineNumbersTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it inserts line numbers within basic php', function () {
     $template = <<<'EOT'
 <?php

--- a/tests/LineNumbers/HeredocLineNumbersTest.php
+++ b/tests/LineNumbers/HeredocLineNumbersTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it doesnt add line numbers to end of heredoc', function () {
     $template = <<<'PHP'
 

--- a/tests/Parsers/ComponentParserTest.php
+++ b/tests/Parsers/ComponentParserTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it parses basic component props directive', function () {
     $template = <<<'BLADE'
 @props(['title', 'type'])

--- a/tests/Pest.php
+++ b/tests/Pest.php
@@ -1,3 +1,11 @@
 <?php
 
-uses(\Stillat\Dagger\Tests\CompilerTestCase::class)->in('Unit', 'Feature');
+uses(\Stillat\Dagger\Tests\CompilerTestCase::class)
+    ->in(
+        'AttributeCache',
+        'Cache',
+        'Compiler',
+        'LineNumbers',
+        'Parsers',
+        'Runtime',
+    );

--- a/tests/Runtime/BladeComponentInteropTest.php
+++ b/tests/Runtime/BladeComponentInteropTest.php
@@ -2,8 +2,6 @@
 
 use Illuminate\Support\Str;
 
-uses(\Stillat\Dagger\Tests\CompilerTestCase::class);
-
 test('it compiles content inside Blade component slots', function () {
     $template = <<<'BLADE'
 <x-alert>

--- a/tests/Runtime/DepthTest.php
+++ b/tests/Runtime/DepthTest.php
@@ -1,7 +1,5 @@
 <?php
 
-uses(\Stillat\Dagger\Tests\CompilerTestCase::class);
-
 test('it retrieves depth using component parent', function () {
     $this->assertSame(
         'Depth: 1',

--- a/tests/Runtime/MixinsTest.php
+++ b/tests/Runtime/MixinsTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('it applies mixin data', function () {
     $this->assertSame(
         'Value from mixin one',

--- a/tests/Runtime/ParentTest.php
+++ b/tests/Runtime/ParentTest.php
@@ -1,7 +1,5 @@
 <?php
 
-uses(\Stillat\Dagger\Tests\CompilerTestCase::class);
-
 test('Blade components can be a parent', function () {
     $expected = <<<'EXPECTED'
 Using class properties:

--- a/tests/Runtime/ValidationTest.php
+++ b/tests/Runtime/ValidationTest.php
@@ -1,9 +1,5 @@
 <?php
 
-use Stillat\Dagger\Tests\CompilerTestCase;
-
-uses(CompilerTestCase::class);
-
 test('invalid props triggers exception', function () {
     $this->expectExceptionMessage('The title property is required.');
     $this->render('<c-validation.basic />');


### PR DESCRIPTION
This PR adds the ability to compile a component using a callback function, without needing a corresponding view file:

```php
<?php

use Stillat\Dagger\Facades\Compiler;

Compiler::compileComponent('c:mycomponent', function ($node) {
    return 'My Component';
});

```

```blade
<c-mycomponent />
```